### PR TITLE
各ファイルを更新する際の処理に排他制御を導入

### DIFF
--- a/test/bbs-main.php
+++ b/test/bbs-main.php
@@ -1116,7 +1116,7 @@ if (!$sage) {
 }
 
 // スレッド一覧 (subject.json)
-if ($newthread || (!$tlonly && !$sage)) {
+if (!$tlonly) {
     // 停止済のスレッド
     if ($stop) $subject = "[stop] ".$subject;
     // 投稿先スレッド
@@ -1135,11 +1135,18 @@ if ($newthread || (!$tlonly && !$sage)) {
             $Threads = [];
         }
         $PAGEFILE = [];
-        $PAGEFILE[] = $posted;
+        if (!$sage || $newthread) {
+            $PAGEFILE[] = $posted;
+        }
         // その他のスレッド
-        if ($Threads) {
-            foreach ($Threads as $thread) {
-                if ($thread['thread'] != $_POST['thread']) $PAGEFILE[] = $thread;
+        foreach ($Threads as $thread) {
+            if ((int) $thread['thread'] === (int) $_POST['thread']){
+                // sageの場合
+                if ($sage && !$newthread) {
+                    $PAGEFILE[] = $posted;
+                }
+            }else{
+                $PAGEFILE[] = $thread;
             }
         }
         // 過去ログ化チェック

--- a/test/bbs-main.php
+++ b/test/bbs-main.php
@@ -1234,7 +1234,7 @@ fclose($logFileHandle);
 $HAP['last'] = $NOWTIME;
 $HAP['comment'] = $_POST['comment'];
 $hapfileHandle = fopen($hapfile, 'w');
-if(flock($hapfileHandle, LOCK_SH)){
+if(flock($hapfileHandle, LOCK_EX)){
     fwrite($hapfileHandle, json_encode($HAP, JSON_UNESCAPED_UNICODE));
 }
 fclose($hapfileHandle);

--- a/test/bbs-main.php
+++ b/test/bbs-main.php
@@ -360,7 +360,9 @@ if (!$newthread && !$tlonly) {
 }
 
 // システムメッセージ用関数
-@include './extend/extra-commands/utilities/add-system-message.php';
+include './extend/extra-commands/utilities/add-system-message.php';
+// スレ状態ファイル読み込み用関数
+include './extend/extra-commands/utilities/get-threads-states.php';
 // !chttコマンド
 @include './extend/extra-commands/chtt.php';
 // !774設定

--- a/test/bbs-main.php
+++ b/test/bbs-main.php
@@ -1042,9 +1042,10 @@ addNewResToDat($THREADFILE, $newRes);
 // 新規スレッドの場合、過去ログ用スレッド一覧(subject.json)に追加
 if ($newthread) {
     $kakoSubjectFile = $PATH."thread/".substr($_POST['thread'], 0, 4)."/subject.json";
+    $fileExists = is_file($kakoSubjectFile);
     $kakoSubjectFileHandle = fopen($kakoSubjectFile, 'c+');
     if(flock($kakoSubjectFileHandle, LOCK_EX)){
-        if(is_file($kakoSubjectFile)){
+        if($fileExists){
             $tlist = json_decode(fread($kakoSubjectFileHandle, filesize($kakoSubjectFile)), true);
         }else{
             $tlist = [];
@@ -1076,9 +1077,10 @@ if (!$sage) {
         $post["title"] = $subject;
         $post["thread"] = $_POST['thread'];
     }
+    $fileExists = is_file($LTLFILE);
     $LTLFILEHandle = fopen($LTLFILE, 'c+');
     if(flock($LTLFILEHandle, LOCK_EX)){
-        if (is_file($LTLFILE)){
+        if ($fileExists){
             $LTL = json_decode(fread($LTLFILEHandle, filesize($LTLFILE)), true);            
         }else{
             $LTL = [];
@@ -1127,9 +1129,10 @@ if (!$tlonly) {
         "date"=>$NOWTIME,
     ];
     // subject.json更新
+    $fileExists = is_file($subjectfile);
     $subjectfileHandle = fopen($subjectfile, 'c+');
     if(flock($subjectfileHandle, LOCK_EX)){
-        if(is_file($subjectfile)){
+        if($fileExists){
             $Threads = json_decode(fread($subjectfileHandle, filesize($subjectfile)), true);
         }else{
             $Threads = [];

--- a/test/extend/commands.php
+++ b/test/extend/commands.php
@@ -45,7 +45,6 @@
     }
    }
 if ($supervisor || $admin) {
-  if (strpos($_POST['comment'], "!") !== false) $reload = true;
   if (strpos($_POST['comment'], '!stop') !== false) $stop = true;
    // 追記
   if (preg_match("/\!add(.*)/", $_POST['comment'], $addMatches) && $number != 1) {
@@ -55,6 +54,7 @@ if ($supervisor || $admin) {
       if(strpos($_POST['comment'], '<hr>') === false) $_POST['comment'] .= '<hr>';
       $_POST['comment'] .= '★追記できる文字数を超えています。<br>';
     }else{
+      $reload = true;
       $messageParts = explode('<hr>', $message);
       $messageParts[0] .="<br><font class=\"add\" color=\"red\">※追記 {$DATE}</font>{$addComment}";
       $message = implode('<hr>', $messageParts);

--- a/test/extend/extra-commands/apply-774.php
+++ b/test/extend/extra-commands/apply-774.php
@@ -33,7 +33,10 @@ function apply774Command(
     if (!is_file($THREADS_STATES_FILE)) {
         return;
     }
-    $threadsStates = json_decode(file_get_contents($THREADS_STATES_FILE), true);
+    $threadsStates = getThreadsStates($THREADS_STATES_FILE);
+    if($threadsStates === false) {
+        return;
+    }
     if(!isset($threadsStates[$_POST['thread']]['774'])) {
         return;
     }

--- a/test/extend/extra-commands/apply-gobi.php
+++ b/test/extend/extra-commands/apply-gobi.php
@@ -23,7 +23,10 @@ function applyGobiCommand(
     if (!is_file($THREADS_STATES_FILE)) {
         return;
     }
-    $threadsStates = json_decode(file_get_contents($THREADS_STATES_FILE), true);
+    $threadsStates = getThreadsStates($THREADS_STATES_FILE);
+    if($threadsStates === false) {
+        return;
+    }
     if(!isset($threadsStates[$_POST['thread']]['gobi'])) {
         return;
     }

--- a/test/extend/extra-commands/utilities/ThreadsStatesUpdater.php
+++ b/test/extend/extra-commands/utilities/ThreadsStatesUpdater.php
@@ -3,7 +3,7 @@
 /**
  * スレ情報ファイルthreads-states.cgiの更新を行うためのクラスです。
  * get()でファイルをロックしput()でロックを解除するので必ずセットで使ってください。※get()でfalseを返した場合put()は不要です。
- * 内容の取得のみを使いたい場合はこのクラスではなくfile_get_contentsを使用してください。
+ * 内容の取得のみを使いたい場合はこのクラスではなくgetThreadsStates関数を使用してください。
  */
 class ThreadsStatesUpdater
 {

--- a/test/extend/extra-commands/utilities/get-threads-states.php
+++ b/test/extend/extra-commands/utilities/get-threads-states.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * スレ情報ファイルthreads-states.cgiの内容を取得するための関数です。
+ * 内容の更新を行いたいときにはThreadsStatesUpdaterクラスを使用してください。
+ *
+ * @param string $path threads-states.cgiへのパス
+ * @return array|false スレ状態の連想配列あるいはfalse
+ */
+function getThreadsStates($path)
+{
+    $threadsStatesHandle = fopen($path, 'r');
+    if(!flock($threadsStatesHandle, LOCK_SH)) {
+        return false;
+    }
+    clearstatcache();
+    $resource = fread($threadsStatesHandle, filesize($path));
+    fclose($threadsStatesHandle);
+    return json_decode($resource, true);
+}

--- a/test/extend/extra-commands/utilities/show-threads-states.php
+++ b/test/extend/extra-commands/utilities/show-threads-states.php
@@ -44,7 +44,10 @@ function showThreadsStates(
         array_push($commentParts, '');
     }
     $commentParts[2] = '';
-    $threadsStates = json_decode(file_get_contents($THREADS_STATES_FILE), true);
+    $threadsStates = getThreadsStates($THREADS_STATES_FILE);
+    if($threadsStates === false) {
+        return;
+    }
     // デフォ名無し情報追加
     if(isset($threadsStates[$_POST['thread']]['774'])) {
         $defaultName = $threadsStates[$_POST['thread']]['774'];


### PR DESCRIPTION
##  概要
現在のコードでは`$THREADFILE`、`$DATFILE`、`subject.json`等のファイルの読み込み及び書き込み処理に`file_get_contents`及び`file_put_contents`を使用しており、複数処理が同時に行われた際にファイルが正しく読み取れなかったり破損する恐れがあります。
したがって排他制御を用いたファイルの更新方法に変更する必要があります。

## 行ったこと
ファイルの更新方法を`fopen`=>`flock(LOCK_SH or LOCK_EX)`=>`fread`=>`(編集)`=>`(fwrite)`=>`fclose` という処理に変更しています。
共有ロックか排他ロックかの選択に関しては、ファイルや処理の都合に合わせて適したものを選んだつもりです。

### 各ファイルについて
#### `$THREADFILE`&`$DATFILE`
通常は追記モードで開き、共有ロックを取って追記しています。
コマンド使用で`>>1`に変更がある場合には排他ロックを取って全体を書き換えています。

#### `subject.json`&`subject.txt`
どちらも排他ロックを取って全体を書き換えています。

#### `HAP`ファイル
こちらは自身しか操作しないはずですが一応排他制御を導入しました。
情報を取得する際には共有ロックで開いて一旦閉じます。書き換える際には再度排他ロックを取って全体を書き換えています。

#### `TL(index.json, dat)`
どちらも排他ロックを取って全体を書き換えています。

#### 	投稿ログ(LOG.cgi)
通常は追記モードで開き、共有ロックを取って追記しています。
ログ数超過で縮小処理がある場合には排他ロックを取って全体を書き換えています。
参考：https://git.3chan.cc/stat2/delightly-v2fork/issues/42

#### スレ状態($threadsStates)の取得
共有ロックを取って読み込んでいます。

#### 過去ログ用`subject.json`
排他ロックを取って全体を書き換えています。

## 別の変更点
`!`が本文中に含まれるだけで`>>1`の変更フラグ(`$reload`)が立っていたので`!add`のみに変更しました。
なお`!chtt`等の追加コマンドでは個別で`$reload`を`true`にする処理が含まれています。

## 変更していない点
今回の変更は掲示板の主な機能が損なわれるのを防ぐために行ったので、規制関連のファイル更新には手を付けていません。
しかし同様の問題が存在するので、今回の修正が上手くいくようなら規制関連のファイル更新処理の修正も同様に行いたいと考えています。

## 〆
排他制御を導入したことにより、パフォーマンスが落ちる可能性が生じます。具体的には書き込みが遅くなったりする恐れがあります。
どれほどの影響があるかは私の手元の環境では予想不可能なので出来るだけ書き込む人の多い環境でテストいただければありがたいです。
また、ご質問やご指摘があればどうぞお知らせください。