### PR TITLE
>>1が更新されるコマンド使用時に専ブラで文字化けする不具合を解消。

### DIFF
--- a/test/bbs-main.php
+++ b/test/bbs-main.php
@@ -383,14 +383,14 @@ function updateFirstRes($datFile, $newFirstRes, $isShiftJis){
     $datFileHandle = fopen($datFile, 'r+');
     if(flock($datFileHandle, LOCK_EX)){
         $datLines = explode("\n", fread($datFileHandle, filesize($datFile)));
-        $datLines[0] = $newFirstRes;
+        if($isShiftJis){
+            $datLines[0] = mb_convert_encoding($newFirstRes, "SJIS-win", "UTF-8");
+        }else{
+            $datLines[0] = $newFirstRes;
+        }
         ftruncate($datFileHandle, 0);
         rewind($datFileHandle);
-        if($isShiftJis){
-            fwrite($datFileHandle, mb_convert_encoding(implode("\n", $datLines), "SJIS-win", "UTF-8"));
-        }else{
-            fwrite($datFileHandle, implode("\n", $datLines));
-        }
+        fwrite($datFileHandle, implode("\n", $datLines));
     }
     fclose($datFileHandle);
 }


### PR DESCRIPTION
!add等の>>1が変更されるコマンドを使用した際に、専ブラ用datファイルが文字化けする不具合を解消しました。