### PR TITLE
fix: Webブラウザ版スレ画面の相対時刻表示を修正。

### DIFF
--- a/static/read.js
+++ b/static/read.js
@@ -184,7 +184,7 @@ function load(mode) {
         let dateids;
         if (dateid) dateids = dateid.split(' ');
         if (!dateids) return;
-        let date = TimeDiff(dateids[0] + ' ' + dateids[1]);
+        let date = TimeDiff(dateids[0] + ' ' + dateids[1] + ' ' + dateids[2]);
         let id = [];
         if (dateids[2]) {
           if (!NG) NG = MuteCheck(dateids[2]);


### PR DESCRIPTION
ご確認お願いいたします。

## 変更点
 - ``read.js``: ``TimeDiff`` 関数に投稿時刻を渡すように変更し、相対時刻の表示がおかしくなっているのを解消